### PR TITLE
Add Seedream AI Studio to AI图像生成 section

### DIFF
--- a/README.md
+++ b/README.md
@@ -59,6 +59,7 @@
 - **[Lexica](https://lexica.art)** - Stable Diffusion搜索引擎和生成器
 - **[SeaArt](https://seaart.ai)** - 免费的AI艺术创作平台
 - **[Tensor Art](https://tensor.art)** - 专业AI图像生成社区
+- **[Seedream AI Studio](https://seedream4.video/)** 🔥🔥 `免费` `字节跳动` `多模型` - 字节跳动出品的AI图像生成平台，搭载Seedream 5.0/4.5/4.0模型，AI图像竞技场排名第一，支持10张参考图，一键Kling 2.1视频生成
 
 ## ✍️ AI 写作助手
 


### PR DESCRIPTION
添加 [Seedream AI Studio](https://seedream4.video/) 到 AI 图像生成部分。

Seedream AI Studio 是字节跳动推出的多模型 AI 图像生成平台，搭载 Seedream 5.0/4.5/4.0 三个模型，在 AI 图像竞技场排名第一。支持最多 10 张参考图进行风格/角色一致性控制，支持一键 Kling 2.1 视频生成。提供免费套餐。