### PR TITLE
feat: add NotFair — open-source Claude Code skills for SEO & paid ads

### DIFF
--- a/README.md
+++ b/README.md
@@ -146,6 +146,7 @@
 - **[OpenAI Codex](https://openai.com/codex)** - OpenAI的代码生成模型
 - **[Sourcegraph Cody](https://sourcegraph.com/cody)** - AI代码搜索和生成
 - **[DeepCode](https://deepcode.ai)** - AI代码审查工具
+- **[NotFair](https://github.com/nowork-studio/NotFair)** 🔥🔥 `开源` `Claude Code` `营销` - 用于SEO、GEO、Google Ads和Meta Ads的开源Claude Code技能集（约2.9k星）；通过Google Ads MCP、Meta Ads MCP、Google Search Console MCP和Google Analytics (GA4) MCP连接实时数据
 
 ---
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -139,6 +139,7 @@
 - **[OpenAI Codex](https://openai.com/codex)** `API` `Code Generation` - OpenAI's code generation model
 - **[Sourcegraph Cody](https://sourcegraph.com/cody)** `Freemium` `Code Search` - AI code search and generation
 - **[DeepCode](https://deepcode.ai)** `Free` `Code Review` - AI code review tool
+- **[NotFair](https://github.com/nowork-studio/NotFair)** 🔥🔥 `Open Source` `Claude Code` `Marketing` - Open-source Claude Code skills for SEO, GEO, Google Ads, and Meta Ads (~2.9k stars); connects to live data via Google Ads MCP, Meta Ads MCP, Google Search Console MCP, and Google Analytics (GA4) MCP
 
 ---
 


### PR DESCRIPTION
Hi! Thanks for maintaining this AI tools directory — it's a great resource.

I'd like to add **[NotFair](https://github.com/nowork-studio/NotFair)**, an open-source Claude Code plugin (~2.9k stars, MIT license) that brings AI-driven marketing automation directly into Claude Code. It covers:

- **SEO & GEO** — site analysis, keyword research, meta tags, schema markup, content writing
- **Google Ads** — audits, wasted-spend detection, search-term cleanup, keyword & bid management
- **Meta Ads** — ROAS analysis, creative fatigue detection, audience overlap

It connects to live data through the **Google Ads MCP**, **Meta Ads MCP**, **Google Search Console MCP**, and **Google Analytics (GA4) MCP**.

I've added it to the **AI Developer Tools** section in both the Chinese and English READMEs, following the existing format. Happy to move it to a different section, adjust the description, or trim anything — just let me know!